### PR TITLE
Migrate from grpc to @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@grpc/proto-loader": "^0.3.0",
-    "grpc": "^1.15.1"
+    "@grpc/grpc-js": "^1.11.1",
+    "@grpc/proto-loader": "^0.7.13"
   },
   "devDependencies": {
     "@types/node": "^10.11.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import * as grpc from "grpc";
-import * as http from "http";
+import {GrpcObject, ServiceClientConstructor, ProtobufTypeDefinition, loadPackageDefinition, credentials, ServiceError} from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 
 const GRPC_SERVER = process.env.DWARF_GRPC_SERVER;
 const PROTO_PATH = __dirname + "./../dwarf.proto";
-let dwarfProto: grpc.GrpcObject;
+let dwarfProto: GrpcObject | ServiceClientConstructor | ProtobufTypeDefinition;
 
 if (!GRPC_SERVER) {
   console.warn("You must set a GRPC server. Dwarf will not work.");
@@ -13,13 +12,12 @@ if (!GRPC_SERVER) {
 export interface ServerResponse {
   urls: string[];
 }
-
-export function grpcObj(): grpc.GrpcObject {
+function grpcObj(): GrpcObject | ServiceClientConstructor | ProtobufTypeDefinition {
   if (dwarfProto) {
     return dwarfProto;
   }
 
-  dwarfProto = grpc.loadPackageDefinition(loadSync(PROTO_PATH)).pb;
+  dwarfProto = loadPackageDefinition(loadSync(PROTO_PATH)).pb;
 
   return dwarfProto;
 }
@@ -27,12 +25,12 @@ export function grpcObj(): grpc.GrpcObject {
 export function shorten(urls: string[]) {
   return new Promise((resolve, reject) => {
     const Proto = grpcObj();
-    const client = new Proto.Dwarf(
+    const client = new (Proto as any).Dwarf(
       GRPC_SERVER,
-      grpc.credentials.createInsecure()
+      credentials.createInsecure()
     );
 
-    client.Create({ urls }, (err: Error, res: ServerResponse) => {
+    client.Create({ urls }, (err: ServiceError | null, res: ServerResponse) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
# Description
 Since the package has been deprecated , I've migrated the codebase from `grpc` to `@grpc/grpc-js`.

# Issue
Causing issue in current node LTS.